### PR TITLE
feat: Add basic CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ on:
       - main
 
 jobs:
-  test:
+  format_and_lint:
     runs-on: ubuntu-latest
 
     steps:
@@ -38,7 +38,27 @@ jobs:
       - name: Run isort
         run: isort .
 
-      # Uncomment when tests are added
+  # Uncomment when tests are added
+  # Test:
+  #   needs: format_and_lint
+  #   steps:
       ## Run Pytest (tests)
       # - name: Run Pytest
       #   run: pytest
+
+  # Bump version number
+  bump_version:
+    runs-on: ubuntu-latest
+
+    needs: [format_and_lint]
+    if: "!startsWith(github.event.head_commit.message, 'bump:')"
+    name: "Bump version and create changelog with commitizen"
+    steps:
+      - name: Check out
+        uses: actions/checkout@v3
+      - name: Create bump and changelog
+        uses: commitizen-tools/commitizen-action@master
+        with:
+          github_token: ${{ secrets.PAT }}
+
+

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout the repository
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      # Set up Python environment
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11" 
+
+      # Install dependencies from the pyproject.toml using dev and test extras
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev,test]
+
+      # Run Ruff (linting)
+      - name: Run Ruff
+        run: ruff check .
+
+      # Run mypy (type checking)
+      - name: Run mypy
+        run: mypy .
+
+      # Run isort (checking imports sorting)
+      - name: Run isort
+        run: isort .
+
+      # Uncomment when tests are added
+      ## Run Pytest (tests)
+      # - name: Run Pytest
+      #   run: pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # Project metadata
 [project]
 name="roiti-gie-client-v2"
-dynamic=["version"]
+version="0.1.0"
 dependencies=[
 	"aiohttp>=3.10.5",
 ]
@@ -26,6 +26,7 @@ dev = [
 	"ruff",
 	"mypy",
 	"isort",
+	"commitizen",
 ]
 test = ["pytest"]
 
@@ -59,3 +60,10 @@ exclude = [
 [tool.isort]
 profile = "hug"
 src_paths = ["isort", "test"]
+
+[tool.commitizen]
+name = "cz_conventional_commits"
+version_provider = "pep621"
+update_changelog_on_bump = true
+changelog_file = "CHANGELOG.md"
+major_version_zero = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dev = [
 	"mypy",
 	"isort",
 ]
+test = ["pytest"]
 
 # [project.urls]
 # Homepage = ""

--- a/src/api_models/platform.py
+++ b/src/api_models/platform.py
@@ -1,7 +1,7 @@
 """An API type enumerator"""
 import enum
- 
- 
+
+
 class APIType(str, enum.Enum):
     """Enumerator class for the two API types"""
  


### PR DESCRIPTION
For the moment CI will only check formatting,
linting and run isort. In the future the idea
is to have the pipeline run the tests,
autogenerate a changelog, bump version, and
autogenerate documentation.